### PR TITLE
chore(tools): remove legacy tools.go from root directory

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -1,1 +1,0 @@
-package tools


### PR DESCRIPTION
The tools.go has been moved to a dedicated tools/ module to isolate build constraints and avoid affecting go vet. This removes the redundant file from the root.