### PR TITLE
chore: add docker-compose.yml and .env.example; update .gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# .env.example
+
+# App config
+PORT=8080
+
+# Database config (compose uses these)
+POSTGRES_USER=gotasker_user
+POSTGRES_PASSWORD=gotasker_pass
+POSTGRES_DB=gotasker_db
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+
+# Full connection string (app uses this)
+DB_URL=postgres://gotasker_user:gotasker_pass@localhost:5432/gotasker_db?sslmode=disable
+
+# JWT secret (example only)
+JWT_SECRET=replace_this_with_real_secret

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Local env
 .env
 .env.*
+!.env.example
 
 # Coverage reports
 coverage.out

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: gotasker_postgres
+    restart: always
+    env_file:
+      - .env
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+
+volumes:
+  pg_data:


### PR DESCRIPTION
### ✅ Changes
- Added `docker-compose.yml` with Postgres 15 container
- Uses `env_file` to load DB config from `.env`
- Added `.env.example` for easy setup
- Updated `.gitignore` to commit `.env.example` but ignore real `.env`

### 🔍 Test Plan
- `cp .env.example .env`
- `docker-compose up -d`
- Verify Postgres container runs
- Use `psql` to connect and check DB creds

### 🚦 Checklist
- [x] docker-compose.yml committed
- [x] .env.example committed
- [x] .env is gitignored
- [x] .gitignore tested locally