### PR TITLE
feat: implement Task model, repository and unit test with SQLite

### DIFF
--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -1,0 +1,14 @@
+package model
+
+import "time"
+
+type Task struct {
+	ID        uint   `gorm:"primaryKey"`
+	UserID    uint   `gorm:"not null;index"`
+	Title     string `gorm:"not null"`
+	Content   string
+	Status    string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time `gorm:"index"`
+}

--- a/internal/repository/task_repository.go
+++ b/internal/repository/task_repository.go
@@ -1,0 +1,57 @@
+package repository
+
+import (
+	"context"
+	"github.com/SoliMark/gotasker-pro/internal/model"
+	"gorm.io/gorm"
+)
+
+type TaskRepository interface {
+	CreateTask(ctx context.Context, task *model.Task) error
+	FindByID(ctx context.Context, id uint) (*model.Task, error)
+	UpdateTask(ctx context.Context, task *model.Task) error
+	DeleteTask(ctx context.Context, id uint) error
+	ListByUserID(ctx context.Context, userID uint) ([]*model.Task, error)
+}
+
+type taskRepository struct {
+	db *gorm.DB
+}
+
+func NewTaskRepository(db *gorm.DB) TaskRepository {
+	return &taskRepository{db: db}
+}
+
+func (r *taskRepository) CreateTask(ctx context.Context, task *model.Task) error {
+	return r.db.WithContext(ctx).Create(task).Error
+}
+
+func (r *taskRepository) FindByID(ctx context.Context, id uint) (*model.Task, error) {
+	var task model.Task
+	err := r.db.WithContext(ctx).First(&task, "id = ?", id).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return &task, nil
+}
+
+func (r *taskRepository) UpdateTask(ctx context.Context, task *model.Task) error {
+	return r.db.WithContext(ctx).Save(task).Error
+}
+
+func (r *taskRepository) DeleteTask(ctx context.Context, id uint) error {
+	return r.db.WithContext(ctx).Delete(&model.Task{}, id).Error
+}
+
+func (r *taskRepository) ListByUserID(ctx context.Context, userID uint) ([]*model.Task, error) {
+	var tasks []*model.Task
+	err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("created_at DESC").
+		Find(&tasks).Error
+	return tasks, err
+}

--- a/internal/repository/task_repository_test.go
+++ b/internal/repository/task_repository_test.go
@@ -1,0 +1,68 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SoliMark/gotasker-pro/internal/model"
+	"github.com/SoliMark/gotasker-pro/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// 使用 SQLite 的 in-memory DB 初始化
+func setupSQLiteTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+
+	// 自動 migrate Task model
+	err = db.AutoMigrate(&model.Task{})
+	assert.NoError(t, err)
+
+	return db
+}
+
+func TestTaskRepository_CRUD_SQLite(t *testing.T) {
+	db := setupSQLiteTestDB(t)
+	repo := repository.NewTaskRepository(db)
+	ctx := context.Background()
+
+	// Create
+	task := &model.Task{
+		UserID:  42,
+		Title:   "SQLite Task",
+		Content: "This is a task in SQLite",
+		Status:  "pending",
+	}
+	err := repo.CreateTask(ctx, task)
+	assert.NoError(t, err)
+	assert.NotZero(t, task.ID)
+
+	// FindByID
+	found, err := repo.FindByID(ctx, task.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, task.Title, found.Title)
+
+	// Update
+	found.Title = "Updated Title"
+	err = repo.UpdateTask(ctx, found)
+	assert.NoError(t, err)
+
+	updated, err := repo.FindByID(ctx, task.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, "Updated Title", updated.Title)
+
+	// ListByUserID
+	list, err := repo.ListByUserID(ctx, task.UserID)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, len(list), 1)
+
+	// Delete
+	err = repo.DeleteTask(ctx, task.ID)
+	assert.NoError(t, err)
+
+	deleted, err := repo.FindByID(ctx, task.ID)
+	assert.NoError(t, err)
+	assert.Nil(t, deleted)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -12,7 +12,7 @@ func SetupRoutes(r *gin.Engine, c *app.Container) {
 
 	// Protected routes with JWT
 	api := r.Group("/api")
-	api.Use(gin.HandlerFunc(c.JWTMiddleware))
+	api.Use(c.JWTMiddleware)
 	{
 		// User Profile
 		api.GET("/profile", c.UserHandler.Profile)


### PR DESCRIPTION
### ✅ What's Done

- `feat`: Add `Task` model under `internal/model/task.go`
- `feat`: Implement `TaskRepository` interface and GORM implementation
- `test`: Add SQLite-based unit tests for `TaskRepository` (CRUD)
- `chore`: Fix redundant `gin.HandlerFunc` wrap on `JWTMiddleware`

---

### 📂 Changed Files

- `internal/model/task.go`
- `internal/repository/task_repository.go`
- `internal/repository/task_repository_test.go`
- `internal/router/router.go`

---

### 🧪 Test Instructions

```bash
go test ./internal/repository -v
```

- Uses `gorm.Open(sqlite.Open(":memory:"))` for fast, isolated local test
- Tests all repository methods: `CreateTask`, `FindByID`, `UpdateTask`, `DeleteTask`, `ListByUserID`
- No Postgres required

---

### 🔜 Next Steps

- Implement `TaskService` + unit tests (gomock)
- Add `TaskHandler` and route group registration
- Integrate Redis cache (ListTasks) + redismock test

---

### 📝 Notes

- The JWTMiddleware fix removes redundant `gin.HandlerFunc(...)`, since it's already a valid `gin.HandlerFunc` type.
