### PR TITLE
chore(style): apply goimports-reviser across repository (no logic changes)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"log"
 
+	"github.com/gin-gonic/gin"
+
 	"github.com/SoliMark/gotasker-pro/internal/app"
 	"github.com/SoliMark/gotasker-pro/internal/router"
-	"github.com/gin-gonic/gin"
 )
 
 func main() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func resetConfig() {

--- a/internal/app/containter.go
+++ b/internal/app/containter.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"gorm.io/gorm"
+
 	"github.com/SoliMark/gotasker-pro/config"
 	"github.com/SoliMark/gotasker-pro/internal/db"
 	"github.com/SoliMark/gotasker-pro/internal/handler"
@@ -8,7 +10,6 @@ import (
 	"github.com/SoliMark/gotasker-pro/internal/repository"
 	"github.com/SoliMark/gotasker-pro/internal/service"
 	"github.com/SoliMark/gotasker-pro/internal/util"
-	"gorm.io/gorm"
 )
 
 type Container struct {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/SoliMark/gotasker-pro/internal/model"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+
+	"github.com/SoliMark/gotasker-pro/internal/model"
 )
 
 func NewDB(dsn string) (*gorm.DB, error) {

--- a/internal/handler/task_handler_test.go
+++ b/internal/handler/task_handler_test.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/SoliMark/gotasker-pro/internal/handler"
 	"github.com/SoliMark/gotasker-pro/internal/model"
 	"github.com/SoliMark/gotasker-pro/internal/service"
 	"github.com/SoliMark/gotasker-pro/internal/service/mock_service"
-	"github.com/gin-gonic/gin"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateTask(t *testing.T) {

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -3,9 +3,10 @@ package handler
 import (
 	"net/http"
 
+	"github.com/gin-gonic/gin"
+
 	"github.com/SoliMark/gotasker-pro/internal/model"
 	"github.com/SoliMark/gotasker-pro/internal/service"
-	"github.com/gin-gonic/gin"
 )
 
 type UserHandler struct {

--- a/internal/handler/user_handler_test.go
+++ b/internal/handler/user_handler_test.go
@@ -8,16 +8,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/SoliMark/gotasker-pro/internal/constant"
 	"github.com/SoliMark/gotasker-pro/internal/handler"
 	"github.com/SoliMark/gotasker-pro/internal/middleware"
 	"github.com/SoliMark/gotasker-pro/internal/service"
 	"github.com/SoliMark/gotasker-pro/internal/service/mock_service"
 	"github.com/SoliMark/gotasker-pro/internal/util"
-	"github.com/gin-gonic/gin"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUserHandler_Register_Success(t *testing.T) {

--- a/internal/middleware/jwt_auth_middleware.go
+++ b/internal/middleware/jwt_auth_middleware.go
@@ -4,9 +4,10 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/gin-gonic/gin"
+
 	"github.com/SoliMark/gotasker-pro/internal/constant"
 	"github.com/SoliMark/gotasker-pro/internal/util"
-	"github.com/gin-gonic/gin"
 )
 
 type JWTMiddleware = gin.HandlerFunc

--- a/internal/repository/task_repository.go
+++ b/internal/repository/task_repository.go
@@ -2,8 +2,10 @@ package repository
 
 import (
 	"context"
-	"github.com/SoliMark/gotasker-pro/internal/model"
+
 	"gorm.io/gorm"
+
+	"github.com/SoliMark/gotasker-pro/internal/model"
 )
 
 type TaskRepository interface {

--- a/internal/repository/task_repository_test.go
+++ b/internal/repository/task_repository_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SoliMark/gotasker-pro/internal/model"
-	"github.com/SoliMark/gotasker-pro/internal/repository"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+
+	"github.com/SoliMark/gotasker-pro/internal/model"
+	"github.com/SoliMark/gotasker-pro/internal/repository"
 )
 
 // 使用 SQLite 的 in-memory DB 初始化

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -3,8 +3,10 @@ package repository
 import (
 	"context"
 	"errors"
-	"github.com/SoliMark/gotasker-pro/internal/model"
+
 	"gorm.io/gorm"
+
+	"github.com/SoliMark/gotasker-pro/internal/model"
 )
 
 type UserRepository interface {

--- a/internal/repository/user_repository_test.go
+++ b/internal/repository/user_repository_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SoliMark/gotasker-pro/internal/model"
-	"github.com/SoliMark/gotasker-pro/internal/repository"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+
+	"github.com/SoliMark/gotasker-pro/internal/model"
+	"github.com/SoliMark/gotasker-pro/internal/repository"
 )
 
 func setupTestDB(t *testing.T) *gorm.DB {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,8 +1,9 @@
 package router
 
 import (
-	"github.com/SoliMark/gotasker-pro/internal/app"
 	"github.com/gin-gonic/gin"
+
+	"github.com/SoliMark/gotasker-pro/internal/app"
 )
 
 func SetupRoutes(r *gin.Engine, c *app.Container) {

--- a/internal/service/user_service_test.go
+++ b/internal/service/user_service_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SoliMark/gotasker-pro/internal/model"
-	"github.com/SoliMark/gotasker-pro/internal/repository/mock_repository"
-	"github.com/SoliMark/gotasker-pro/internal/util"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/SoliMark/gotasker-pro/internal/model"
+	"github.com/SoliMark/gotasker-pro/internal/repository/mock_repository"
+	"github.com/SoliMark/gotasker-pro/internal/util"
 )
 
 func TestCreateUser_Success(t *testing.T) {

--- a/internal/util/jwt.go
+++ b/internal/util/jwt.go
@@ -3,7 +3,7 @@ package util
 import (
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 type JWTMaker struct {


### PR DESCRIPTION
### Purpose
Apply `goimports-reviser` formatting to the entire repository to align with the import style rules introduced in PR-A.

### Changes
- Group imports into:
  1) standard library
  2) company prefixes (`github.com/SoliMark`)
  3) project-local (`github.com/SoliMark/gotasker-pro/...`)
- Order imports alphabetically within each group.
- Remove unused imports.
- Add aliases where needed to avoid conflicts.

### Scope & Notes
- **No functional or logic changes** — this is a style-only PR.
- Generated files are excluded (patterns: `zz_generated`, `mock_*.go`, `*_gen.go`).
- This is a one-time bulk reformat to establish a clean baseline.

### How to Review
- Skim changes at a high level; no line-by-line functional review is required.
- Verify:
  - Build passes: `go build ./...`
  - Tests pass: `go test -v ./cmd/... ./config/... ./internal/...`
  - Lint passes: `golangci-lint run --config .golangci.yml ./cmd/... ./config/... ./internal/...`
- Future PRs will be automatically enforced by pre-commit and CI (Imports Check workflow).

### Risks
- Minimal. Merge conflicts may occur with long-lived branches; recommend rebasing those branches after this PR merges.
