### PR TITLE
refactor(config): migrate to mapstructure-based unmarshal with required field validation

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,7 @@ func resetConfig() {
 func TestLoadConfig_WithEnvVars(t *testing.T) {
 	t.Setenv("PORT", "9999")
 	t.Setenv("DB_URL", "postgres://localhost:5432/testdb")
+	t.Setenv("JWT_SECRET", "test-secret")
 
 	resetConfig()
 
@@ -28,6 +29,7 @@ func TestLoadConfig_WithEnvVars(t *testing.T) {
 
 func TestLoadConfig_FallbackPort(t *testing.T) {
 	t.Setenv("DB_URL", "postgres://localhost:5432/testdb")
+	t.Setenv("JWT_SECRET", "test-secret")
 
 	resetConfig()
 	c, err := LoadConfig()

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
## Summary
Refactor `LoadConfig` to use `viper.Unmarshal` with `mapstructure` instead of manual `GetString` calls.  
This change improves maintainability and allows type-safe decoding (e.g., `time.Duration`) from environment variables.

## Changes
- Introduced `github.com/mitchellh/mapstructure`.
- Added `mapstructure` tags to `Config` struct.
- Bound environment variables explicitly so `Unmarshal` can populate struct fields.
- Added required field validation for `DB_URL` and `JWT_SECRET`.
- Documented Viper's value priority order in code comments.
- Updated unit tests to set `JWT_SECRET` to pass validation.

## Motivation
Prepares `Config` for future additions (e.g., Redis, cache TTL) while ensuring a cleaner, testable configuration loading path.

## How to Test
1. Run `go test ./config` — all tests should pass.
2. Try running without `DB_URL` or `JWT_SECRET` env vars — should fail fast with an error.
3. Verify that `PORT` falls back to default `8080` when not set.
4. Verify that env vars override `.env` and defaults.

## Checklist
- [x] Code compiles locally
- [x] Unit tests updated and passing
- [x] No breaking changes to existing config keys
