### PR TITLE
fix: use consistent context key for user_id

### DIFF
--- a/internal/handler/task_handler.go
+++ b/internal/handler/task_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/SoliMark/gotasker-pro/internal/constant"
 	"github.com/SoliMark/gotasker-pro/internal/model"
 	"github.com/SoliMark/gotasker-pro/internal/service"
 	"github.com/SoliMark/gotasker-pro/internal/util"
@@ -44,7 +45,7 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 		return
 	}
 
-	userID, exists := c.Get("userID")
+	userID, exists := c.Get(constant.ContextUserIDKey)
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
@@ -71,7 +72,7 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 }
 
 func (h *TaskHandler) GetTask(c *gin.Context) {
-	userID, exists := c.Get("userID")
+	userID, exists := c.Get(constant.ContextUserIDKey)
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
@@ -107,7 +108,7 @@ func (h *TaskHandler) GetTask(c *gin.Context) {
 }
 
 func (h *TaskHandler) ListTasks(c *gin.Context) {
-	userID, exists := c.Get("userID")
+	userID, exists := c.Get(constant.ContextUserIDKey)
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
@@ -132,7 +133,7 @@ func (h *TaskHandler) ListTasks(c *gin.Context) {
 }
 
 func (h *TaskHandler) UpdateTask(c *gin.Context) {
-	userID, exists := c.Get("userID")
+	userID, exists := c.Get(constant.ContextUserIDKey)
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
@@ -197,7 +198,7 @@ func (h *TaskHandler) UpdateTask(c *gin.Context) {
 }
 
 func (h *TaskHandler) DeleteTask(c *gin.Context) {
-	userIDVal, exists := c.Get("userID")
+	userIDVal, exists := c.Get(constant.ContextUserIDKey)
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return

--- a/internal/handler/task_handler_test.go
+++ b/internal/handler/task_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/SoliMark/gotasker-pro/internal/constant"
 	"github.com/SoliMark/gotasker-pro/internal/handler"
 	"github.com/SoliMark/gotasker-pro/internal/model"
 	"github.com/SoliMark/gotasker-pro/internal/service"
@@ -26,7 +27,7 @@ func TestCreateTask(t *testing.T) {
 
 	router := gin.Default()
 	router.POST("/tasks", func(c *gin.Context) {
-		c.Set("userID", uint(1))
+		c.Set(constant.ContextUserIDKey, uint(1))
 		h.CreateTask(c)
 	})
 
@@ -64,7 +65,7 @@ func TestGetTask(t *testing.T) {
 
 	router := gin.Default()
 	router.GET("/tasks/:id", func(c *gin.Context) {
-		c.Set("userID", uint(1))
+		c.Set(constant.ContextUserIDKey, uint(1))
 		h.GetTask(c)
 	})
 
@@ -117,7 +118,7 @@ func TestListTaskss(t *testing.T) {
 
 	router := gin.Default()
 	router.GET("/tasks", func(c *gin.Context) {
-		c.Set("userID", uint(1))
+		c.Set(constant.ContextUserIDKey, uint(1))
 		h.ListTasks(c)
 	})
 
@@ -146,7 +147,7 @@ func TestUpdateTask(t *testing.T) {
 
 	router := gin.Default()
 	router.PUT("/tasks/:id", func(c *gin.Context) {
-		c.Set("userID", uint(1))
+		c.Set(constant.ContextUserIDKey, uint(1))
 		h.UpdateTask(c)
 	})
 
@@ -220,7 +221,7 @@ func TestDeleteTask(t *testing.T) {
 		req := httptest.NewRequest(http.MethodDelete, "/tasks/abc", nil)
 		c.Request = req
 		c.Params = gin.Params{{Key: "id", Value: "abc"}}
-		c.Set("userID", uint(1))
+		c.Set(constant.ContextUserIDKey, uint(1))
 
 		h := handler.NewTaskHandler(mockSvc)
 		h.DeleteTask(c)
@@ -255,7 +256,7 @@ func TestDeleteTask(t *testing.T) {
 		req := httptest.NewRequest(http.MethodDelete, "/tasks/1", nil)
 		c.Request = req
 		c.Params = gin.Params{{Key: "id", Value: "1"}}
-		c.Set("userID", uint(1))
+		c.Set(constant.ContextUserIDKey, uint(1))
 
 		mockSvc.EXPECT().
 			DeleteTask(gomock.Any(), uint(1), uint(1)).
@@ -277,7 +278,7 @@ func TestDeleteTask(t *testing.T) {
 		req := httptest.NewRequest(http.MethodDelete, "/tasks/2", nil)
 		c.Request = req
 		c.Params = gin.Params{{Key: "id", Value: "2"}}
-		c.Set("userID", uint(1))
+		c.Set(constant.ContextUserIDKey, uint(1))
 
 		mockSvc.EXPECT().
 			DeleteTask(gomock.Any(), uint(1), uint(2)).
@@ -299,7 +300,7 @@ func TestDeleteTask(t *testing.T) {
 		req := httptest.NewRequest(http.MethodDelete, "/tasks/3", nil)
 		c.Request = req
 		c.Params = gin.Params{{Key: "id", Value: "3"}}
-		c.Set("userID", uint(1))
+		c.Set(constant.ContextUserIDKey, uint(1))
 
 		mockSvc.EXPECT().
 			DeleteTask(gomock.Any(), uint(1), uint(3)).
@@ -321,7 +322,7 @@ func TestDeleteTask(t *testing.T) {
 		req := httptest.NewRequest(http.MethodDelete, "/tasks/10", nil)
 		c.Request = req
 		c.Params = gin.Params{{Key: "id", Value: "10"}}
-		c.Set("userID", uint(1))
+		c.Set(constant.ContextUserIDKey, uint(1))
 
 		mockSvc.EXPECT().
 			DeleteTask(gomock.Any(), uint(1), uint(10)).

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/SoliMark/gotasker-pro/internal/constant"
 	"github.com/SoliMark/gotasker-pro/internal/model"
 	"github.com/SoliMark/gotasker-pro/internal/service"
 )
@@ -100,7 +101,7 @@ func (h *UserHandler) Login(c *gin.Context) {
 }
 
 func (h *UserHandler) Profile(c *gin.Context) {
-	userID, exists := c.Get("user_id")
+	userID, exists := c.Get(constant.ContextUserIDKey)
 	if !exists {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Error: "user_id not found in context",


### PR DESCRIPTION
# 🐛 Bug Fix: Context Key Consistency Issue

## 🎯 Overview
This PR fixes a critical inconsistency in context key usage between JWT middleware and handlers, which was causing authorization failures in integration tests. The issue was that handlers were using different context keys (`"userID"` vs `"user_id"`) than what the JWT middleware was setting (`constant.ContextUserIDKey`).

## ✨ What's Changed

### 🐛 Problem Identified
- **JWT Middleware** sets user ID in context using `constant.ContextUserIDKey` (value: `"user_id"`)
- **Task Handler** was retrieving user ID using hardcoded `"userID"`
- **User Handler** was using hardcoded `"user_id"`
- This mismatch caused all authenticated requests to fail with `401 Unauthorized`

### ✅ Solution Implemented
- Replace all hardcoded context key strings with `constant.ContextUserIDKey`
- Ensure consistency across all handlers and tests
- Use the centralized constant to prevent future inconsistencies

### 🔧 Files Modified
- **`internal/handler/task_handler.go`**: Fixed context key in all 5 methods (CreateTask, GetTask, ListTasks, UpdateTask, DeleteTask)
- **`internal/handler/user_handler.go`**: Fixed context key in Profile method
- **`internal/handler/task_handler_test.go`**: Updated all test cases to use correct context key

### 💻 Code Changes
```go
// Before
userID, exists := c.Get("userID")  // ❌ Inconsistent

// After  
userID, exists := c.Get(constant.ContextUserIDKey)  // ✅ Consistent
```

## 📊 Changes Summary
- **Files Modified**: 3
- **Lines Added**: 18
- **Lines Removed**: 15
- **Net Addition**: 3 lines

## 🧪 Testing
- ✅ All unit tests passed
- ✅ Code compiles successfully
- ✅ Pre-commit hooks passed (linting, formatting, etc.)
- ✅ Integration tests should now work correctly (context key mismatch was the root cause)

## 🎯 Benefits
1. **Fixed Authorization**: Resolves 401 Unauthorized errors in authenticated requests
2. **Better Maintainability**: Single source of truth for context keys
3. **Prevents Future Bugs**: Centralized constant usage prevents inconsistencies
4. **Integration Test Ready**: Fixes the root cause of integration test failures

## 🔍 Review Checklist
- [x] Bug fix addresses the root cause
- [x] All tests pass
- [x] Code follows project conventions
- [x] No breaking changes introduced
- [x] Context key usage is now consistent
- [x] Pre-commit hooks pass

## 🚀 Ready for Review
This PR is ready for review and merge. The context key consistency fix resolves authorization failures and improves code maintainability.

---

**Branch**: `fix/context-key-consistency` → `main`  
**Type**: 🐛 Bug Fix  
**Breaking Changes**: None  
**Dependencies**: None

